### PR TITLE
Fix redirect url

### DIFF
--- a/src/main/java/songbox/house/service/impl/GoogleAuthenticationServiceImpl.java
+++ b/src/main/java/songbox/house/service/impl/GoogleAuthenticationServiceImpl.java
@@ -180,7 +180,7 @@ public class GoogleAuthenticationServiceImpl implements GoogleAuthenticationServ
 
     private String getRedirectUrl(String requestUrl) {
         GenericUrl url = new GenericUrl(requestUrl);
-        url.setRawPath(YOUTUBE_TOKEN_URL);
+        url.appendRawPath(YOUTUBE_TOKEN_URL);
         return url.build();
     }
 }


### PR DESCRIPTION
Use `appendRawPath` instead of `setRawPath`, to fix the issue when `requestUrl` contains path i.e. `domain.com/songboxhouse`