### PR TITLE
Scheduled search reprocessing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext.jacksonVersion = '2.9.8'
 
 dependencies {
     implementation('com.github.Denstden:songbox-house-search-api:0.1.22')
-    implementation('com.github.Denstden:songbox-house-util:0.0.21')
+    implementation('com.github.Denstden:songbox-house-util:0.0.22')
 //    implementation(project(":songbox-house-search-api"))
 //    implementation(project(":songbox-house-util"))
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,13 @@ repositories {
 ext.jacksonVersion = '2.9.8'
 
 dependencies {
-//    implementation('com.github.Denstden:songbox-house-search-api:0.1.22')
-//    implementation('com.github.Denstden:songbox-house-util:0.0.22')
-    implementation(project(":songbox-house-search-api"))
-    implementation(project(":songbox-house-util"))
-    implementation(project(":songbox-house-redis-dao"))
+    implementation('com.github.Denstden:songbox-house-search-api:0.1.22')
+    implementation('com.github.Denstden:songbox-house-util:0.0.23')
+    implementation('com.github.Denstden:songbox-house-redis-dao:1.0.2')
+
+//    implementation(project(":songbox-house-search-api"))
+//    implementation(project(":songbox-house-util"))
+//    implementation(project(":songbox-house-redis-dao"))
 
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
     compile 'org.springframework.kafka:spring-kafka:2.2.4.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,11 @@ repositories {
 ext.jacksonVersion = '2.9.8'
 
 dependencies {
-    implementation('com.github.Denstden:songbox-house-search-api:0.1.22')
-    implementation('com.github.Denstden:songbox-house-util:0.0.22')
-//    implementation(project(":songbox-house-search-api"))
-//    implementation(project(":songbox-house-util"))
+//    implementation('com.github.Denstden:songbox-house-search-api:0.1.22')
+//    implementation('com.github.Denstden:songbox-house-util:0.0.22')
+    implementation(project(":songbox-house-search-api"))
+    implementation(project(":songbox-house-util"))
+    implementation(project(":songbox-house-redis-dao"))
 
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
     compile 'org.springframework.kafka:spring-kafka:2.2.4.RELEASE'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
-include ':songbox-house-search-api', ':songbox-house-util'
+include ':songbox-house-search-api', ':songbox-house-util', ':songbox-house-redis-dao'
 project(":songbox-house-search-api").projectDir = file("./../songbox-house-search-api")
 project(":songbox-house-util").projectDir = file("./../songbox-house-util")
+project(":songbox-house-redis-dao").projectDir = file("./../songbox-house-redis-dao")

--- a/src/main/java/songbox/house/domain/dto/SearchReprocessResultDto.java
+++ b/src/main/java/songbox/house/domain/dto/SearchReprocessResultDto.java
@@ -1,0 +1,18 @@
+package songbox.house.domain.dto;
+
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import songbox.house.domain.dto.response.TrackMetadataDto;
+
+import java.util.Set;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Data
+@FieldDefaults(level = PRIVATE)
+public class SearchReprocessResultDto {
+    Long ownerId;
+    Long collectionId;
+    Set<String> genres;
+    TrackMetadataDto trackMetadata;
+}

--- a/src/main/java/songbox/house/domain/entity/SearchReprocess.java
+++ b/src/main/java/songbox/house/domain/entity/SearchReprocess.java
@@ -1,0 +1,60 @@
+package songbox.house.domain.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import java.util.Date;
+
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.GenerationType.AUTO;
+import static javax.persistence.TemporalType.TIMESTAMP;
+import static songbox.house.domain.entity.SearchReprocessStatus.NOT_FOUND;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "SEARCH_REPROCESS")
+@NoArgsConstructor
+public class SearchReprocess {
+    @Id
+    @GeneratedValue(strategy = AUTO)
+    @Column
+    Long id;
+    @Column(nullable = false)
+    String searchQuery;
+    @Column(nullable = false)
+    Long userId;
+    @Column
+    Long collectionId;
+    @Column
+    Integer retries = 0;
+    @CreationTimestamp
+    @Temporal(TIMESTAMP)
+    @Column
+    Date createdAt;
+    @UpdateTimestamp
+    @Temporal(TIMESTAMP)
+    @Column
+    Date updatedAt;
+    @Temporal(TIMESTAMP)
+    @Column
+    Date downloadedAt;
+    @Temporal(TIMESTAMP)
+    @Column
+    Date foundAt;
+    @Column
+    @Enumerated(STRING)
+    SearchReprocessStatus status = NOT_FOUND;
+    @Column
+    String genres;
+}

--- a/src/main/java/songbox/house/domain/entity/SearchReprocessStatus.java
+++ b/src/main/java/songbox/house/domain/entity/SearchReprocessStatus.java
@@ -1,0 +1,5 @@
+package songbox.house.domain.entity;
+
+public enum SearchReprocessStatus {
+    FOUND, NOT_FOUND, DOWNLOADED
+}

--- a/src/main/java/songbox/house/domain/entity/user/UserInfo.java
+++ b/src/main/java/songbox/house/domain/entity/user/UserInfo.java
@@ -26,8 +26,6 @@ import static javax.persistence.CascadeType.DETACH;
 import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.CascadeType.REFRESH;
-import static javax.persistence.FetchType.EAGER;
-import static javax.persistence.FetchType.LAZY;
 
 @Table
 @Entity

--- a/src/main/java/songbox/house/domain/entity/user/UserProperty.java
+++ b/src/main/java/songbox/house/domain/entity/user/UserProperty.java
@@ -34,9 +34,15 @@ public class UserProperty {
     @Column(name = "search_audio_preview_enabled", columnDefinition = "boolean default false", nullable = false)
     private Boolean searchPreviewEnabled = false;
 
+    //TODO remove
     @Column(length = 2048)
     private String vkCookie;
 
     @OneToOne(cascade = { PERSIST, MERGE, REFRESH, DETACH })
     private MusicCollection defaultCollection;
+
+
+    //autoSearchReprocessEnabled
+    //autoSearchReprocessDownloadEnabled
+    //private Long mask;
 }

--- a/src/main/java/songbox/house/domain/entity/user/UserProperty.java
+++ b/src/main/java/songbox/house/domain/entity/user/UserProperty.java
@@ -16,7 +16,12 @@ import static javax.persistence.CascadeType.DETACH;
 import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.CascadeType.REFRESH;
-import static javax.persistence.FetchType.LAZY;
+import static songbox.house.domain.entity.user.UserPropertyMask.AUTO_DOWNLOAD_SEARCH_REPROCESS_ENABLED;
+import static songbox.house.domain.entity.user.UserPropertyMask.AUTO_SEARCH_REPROCESS_AFTER_FAIL_ENABLED;
+import static songbox.house.domain.entity.user.UserPropertyMask.AUTO_USE_FULL_SEARCH_IF_FAST_NOT_SUCCESS;
+import static songbox.house.domain.entity.user.UserPropertyMask.SEARCH_REPROCESS_ENABLED;
+import static songbox.house.domain.entity.user.UserPropertyMask.USE_ALWAYS_FULL_SEARCH;
+import static songbox.house.util.MaskUtil.hasMask;
 
 @Table
 @Entity
@@ -28,21 +33,41 @@ public class UserProperty {
     @Column
     private Long userPropId;
 
+    //TODO remove after clearing DB -> add new bit in the mask
     @Column
     private Boolean telegramBotUseGoogleDrive;
 
+    //TODO remove after clearing DB -> add new bit in the mask
     @Column(name = "search_audio_preview_enabled", columnDefinition = "boolean default false", nullable = false)
     private Boolean searchPreviewEnabled = false;
 
-    //TODO remove
+    //TODO remove after clearing DB(unused)
     @Column(length = 2048)
     private String vkCookie;
 
     @OneToOne(cascade = { PERSIST, MERGE, REFRESH, DETACH })
     private MusicCollection defaultCollection;
 
+    @Column
+    private Long mask = 0L;
 
-    //autoSearchReprocessEnabled
-    //autoSearchReprocessDownloadEnabled
-    //private Long mask;
+    public boolean isSearchReprocessEnabled() {
+        return hasMask(mask, SEARCH_REPROCESS_ENABLED);
+    }
+
+    public boolean isAutoSearchReprocessAfterFailEnabled() {
+        return isSearchReprocessEnabled() && hasMask(mask, AUTO_SEARCH_REPROCESS_AFTER_FAIL_ENABLED);
+    }
+
+    public boolean isAutoDownloadSearchReprocessEnabled() {
+        return isSearchReprocessEnabled() && hasMask(mask, AUTO_DOWNLOAD_SEARCH_REPROCESS_ENABLED);
+    }
+
+    public boolean isUseFullSearchIfFastFailsEnabled() {
+        return hasMask(mask, AUTO_USE_FULL_SEARCH_IF_FAST_NOT_SUCCESS);
+    }
+
+    public boolean isUseAlwaysFullSearch() {
+        return hasMask(mask, USE_ALWAYS_FULL_SEARCH);
+    }
 }

--- a/src/main/java/songbox/house/domain/entity/user/UserPropertyMask.java
+++ b/src/main/java/songbox/house/domain/entity/user/UserPropertyMask.java
@@ -1,0 +1,23 @@
+package songbox.house.domain.entity.user;
+
+import songbox.house.util.Mask;
+
+public enum UserPropertyMask implements Mask {
+
+    SEARCH_REPROCESS_ENABLED(1),
+    AUTO_SEARCH_REPROCESS_AFTER_FAIL_ENABLED(1 << 1),
+    AUTO_DOWNLOAD_SEARCH_REPROCESS_ENABLED(1 << 2),
+    AUTO_USE_FULL_SEARCH_IF_FAST_NOT_SUCCESS(1 << 3),
+    USE_ALWAYS_FULL_SEARCH(1 << 4);
+
+    private final long mask;
+
+    UserPropertyMask(long mask) {
+        this.mask = mask;
+    }
+
+    @Override
+    public long getMask() {
+        return mask;
+    }
+}

--- a/src/main/java/songbox/house/event/SearchReprocessFoundEvent.java
+++ b/src/main/java/songbox/house/event/SearchReprocessFoundEvent.java
@@ -1,0 +1,36 @@
+package songbox.house.event;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.springframework.context.ApplicationEvent;
+import songbox.house.domain.dto.SearchReprocessResultDto;
+
+import java.util.Map;
+
+public class SearchReprocessFoundEvent extends ApplicationEvent {
+
+    private final Long userId;
+    private final Map<Long, SearchReprocessResultDto> reprocessResultIdToReprocessResultMap;
+
+    public SearchReprocessFoundEvent(Object source, Long userId,
+            Map<Long, SearchReprocessResultDto> reprocessResultIdToReprocessResultMap) {
+        super(source);
+        this.userId = userId;
+        this.reprocessResultIdToReprocessResultMap = reprocessResultIdToReprocessResultMap;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Map<Long, SearchReprocessResultDto> getReprocessResultIdToReprocessResultMap() {
+        return reprocessResultIdToReprocessResultMap;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("userId", userId)
+                .append("reprocessResultIdToReprocessResultMap", reprocessResultIdToReprocessResultMap)
+                .toString();
+    }
+}

--- a/src/main/java/songbox/house/event/listener/LoggingSearchReprocessFoundEventListener.java
+++ b/src/main/java/songbox/house/event/listener/LoggingSearchReprocessFoundEventListener.java
@@ -1,0 +1,15 @@
+package songbox.house.event.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import songbox.house.event.SearchReprocessFoundEvent;
+
+@Component
+@Slf4j
+public class LoggingSearchReprocessFoundEventListener implements ApplicationListener<SearchReprocessFoundEvent> {
+    @Override
+    public void onApplicationEvent(SearchReprocessFoundEvent searchReprocessFoundEvent) {
+        log.info("Received event: {}", searchReprocessFoundEvent);
+    }
+}

--- a/src/main/java/songbox/house/repository/SearchReprocessRepository.java
+++ b/src/main/java/songbox/house/repository/SearchReprocessRepository.java
@@ -1,0 +1,59 @@
+package songbox.house.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import songbox.house.domain.entity.SearchReprocess;
+import songbox.house.domain.entity.SearchReprocessStatus;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Repository
+public interface SearchReprocessRepository extends CrudRepository<SearchReprocess, Long> {
+    @Query(value = "select distinct s.userId from SearchReprocess s where s.status = ?1")
+    Iterable<Long> findAllUsersForReprocess(SearchReprocessStatus status);
+
+    Page<SearchReprocess> findByUserId(Long userId, Pageable pageable);
+
+    Optional<SearchReprocess> findByUserIdAndSearchQuery(Long userId, String searchQuery);
+
+    Page<SearchReprocess> findByUserIdAndStatus(Long userId, SearchReprocessStatus status, Pageable pageable);
+
+    @Modifying
+    @Query("update SearchReprocess u set u.status = songbox.house.domain.entity.SearchReprocessStatus.DOWNLOADED, " +
+            "u.downloadedAt = :downloadedAt where u.id in (:ids)")
+    void setDownloaded(@Param("downloadedAt") Date downloadedAt, @Param("ids") Set<Long> ids);
+
+    @Modifying
+    @Query("update SearchReprocess u set u.status = songbox.house.domain.entity.SearchReprocessStatus.FOUND, u.foundAt = :foundAt where u.id in (:ids)")
+    void setFound(@Param("foundAt") Date foundAt, @Param("ids") List<Long> ids);
+
+    @Modifying
+    @Query("update SearchReprocess u set u.status = songbox.house.domain.entity.SearchReprocessStatus.NOT_FOUND, " +
+            "u.foundAt = null " +
+            "where u.status = songbox.house.domain.entity.SearchReprocessStatus.FOUND and u.id not in (:ids)")
+    void setNotFound(@Param("ids") Set<Long> foundIds);
+
+    @Modifying
+    @Query("update SearchReprocess u set u.status = songbox.house.domain.entity.SearchReprocessStatus.NOT_FOUND, " +
+            "u.foundAt = null " +
+            "where u.status = songbox.house.domain.entity.SearchReprocessStatus.FOUND and u.userId = :userId")
+    void setNotFound(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("update SearchReprocess u set u.status = songbox.house.domain.entity.SearchReprocessStatus.NOT_FOUND, " +
+            "u.foundAt = null " +
+            "where u.id = :id")
+    void setNotFoundById(@Param("id") Long id);
+
+    @Modifying
+    @Query("update SearchReprocess u set u.retries = u.retries + 1 where u.id in (:ids)")
+    void incrementRetryCount(@Param("ids") Set<Long> ids);
+}

--- a/src/main/java/songbox/house/repository/SearchReprocessResultRepository.java
+++ b/src/main/java/songbox/house/repository/SearchReprocessResultRepository.java
@@ -1,0 +1,16 @@
+package songbox.house.repository;
+
+import songbox.house.domain.dto.SearchReprocessResultDto;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface SearchReprocessResultRepository {
+    void save(Long userId, Map<Long, SearchReprocessResultDto> reprocessResult);
+
+    Map<Long, SearchReprocessResultDto> get(Long userId, Set<Long> searchReprocessIds);
+
+    Map<Long, SearchReprocessResultDto> available(Long userId);
+
+    void remove(Long userId, Set<Long> downloadedReprocessIds);
+}

--- a/src/main/java/songbox/house/repository/impl/InMemorySearchReprocessResultRepository.java
+++ b/src/main/java/songbox/house/repository/impl/InMemorySearchReprocessResultRepository.java
@@ -1,5 +1,6 @@
 package songbox.house.repository.impl;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Repository;
 import songbox.house.domain.dto.SearchReprocessResultDto;
 import songbox.house.repository.SearchReprocessResultRepository;
@@ -14,6 +15,7 @@ import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toMap;
 
 @Repository
+@ConditionalOnProperty(name = "songbox.house.search.reprocess.redis", havingValue = "false")
 public class InMemorySearchReprocessResultRepository implements SearchReprocessResultRepository {
 
     private static final Map<Long, Map<Long, SearchReprocessResultDto>> CACHE = new ConcurrentHashMap<>();

--- a/src/main/java/songbox/house/repository/impl/InMemorySearchReprocessResultRepository.java
+++ b/src/main/java/songbox/house/repository/impl/InMemorySearchReprocessResultRepository.java
@@ -1,0 +1,60 @@
+package songbox.house.repository.impl;
+
+import org.springframework.stereotype.Repository;
+import songbox.house.domain.dto.SearchReprocessResultDto;
+import songbox.house.repository.SearchReprocessResultRepository;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toMap;
+
+@Repository
+public class InMemorySearchReprocessResultRepository implements SearchReprocessResultRepository {
+
+    private static final Map<Long, Map<Long, SearchReprocessResultDto>> CACHE = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(Long userId, Map<Long, SearchReprocessResultDto> reprocessResult) {
+        final Map<Long, SearchReprocessResultDto> byUser = CACHE.get(userId);
+        if (isNull(byUser)) {
+            CACHE.put(userId, new ConcurrentHashMap<>(reprocessResult));
+        } else {
+            byUser.putAll(reprocessResult);
+        }
+    }
+
+    @Override
+    public Map<Long, SearchReprocessResultDto> get(Long userId, Set<Long> searchReprocessIds) {
+        final Map<Long, SearchReprocessResultDto> byUser = CACHE.get(userId);
+        if (isNull(byUser)) {
+            return emptyMap();
+        } else {
+            return byUser.entrySet().stream()
+                    .filter(entry -> searchReprocessIds.contains(entry.getKey()))
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+    }
+
+    @Override
+    public Map<Long, SearchReprocessResultDto> available(Long userId) {
+        final Map<Long, SearchReprocessResultDto> byUser = CACHE.get(userId);
+        if (isNull(byUser)) {
+            return emptyMap();
+        } else {
+            return byUser;
+        }
+    }
+
+    @Override
+    public void remove(Long userId, Set<Long> downloadedReprocessIds) {
+        final Map<Long, SearchReprocessResultDto> byUser = CACHE.get(userId);
+        if (nonNull(byUser)) {
+            downloadedReprocessIds.forEach(byUser::remove);
+        }
+    }
+}

--- a/src/main/java/songbox/house/repository/impl/RedisSearchReprocessResultRepository.java
+++ b/src/main/java/songbox/house/repository/impl/RedisSearchReprocessResultRepository.java
@@ -1,0 +1,92 @@
+package songbox.house.repository.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import songbox.house.domain.dto.SearchReprocessResultDto;
+import songbox.house.infrastructure.redis.RedisDAO;
+import songbox.house.infrastructure.redis.RedisDAOImpl;
+import songbox.house.repository.SearchReprocessResultRepository;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
+import static java.util.stream.Collectors.toSet;
+
+@Component
+@Slf4j
+@ConditionalOnProperty(name = "songbox.house.search.reprocess.redis", matchIfMissing = true, havingValue = "true")
+public class RedisSearchReprocessResultRepository implements SearchReprocessResultRepository {
+
+    private final RedisDAO redisDAO;
+    private final ObjectMapper objectMapper;
+
+    public RedisSearchReprocessResultRepository(
+            @Value("${songbox.house.search.reprocess.result.redis.host:localhost}") String host,
+            @Value("${songbox.house.search.reprocess.result.redis.port:36379}") Integer port,
+            @Value("${songbox.house.search.reprocess.result.redis.password:d0cker}") String password,
+            @Value("${songbox.house.search.reprocess.result.redis.db.index:1}") Integer dbIndex,
+            @Value("${songbox.house.search.reprocess.result.redis.timeout.ms:2000}") Integer timeoutMs) {
+        this.redisDAO = new RedisDAOImpl(host, port, password, dbIndex, timeoutMs);
+        this.objectMapper = new ObjectMapper()
+                .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+                .disable(FAIL_ON_EMPTY_BEANS);
+    }
+
+    @Override
+    public void save(Long userId, Map<Long, SearchReprocessResultDto> reprocessResult) {
+        String key = getKey(userId);
+        redisDAO.doInPipeline(pipeline -> {
+            reprocessResult.forEach((k, v) -> pipeline.hset(key, String.valueOf(k), serialize(v)));
+        });
+    }
+
+    @Override
+    public Map<Long, SearchReprocessResultDto> get(Long userId, Set<Long> searchReprocessIds) {
+        String key = getKey(userId);
+        return redisDAO.hgetAll(key).entrySet().stream()
+                .filter(entry -> searchReprocessIds.contains(Long.valueOf(entry.getKey())))
+                .collect(Collectors.toMap(e -> Long.valueOf(e.getKey()), e -> deserialize(e.getValue())));
+    }
+
+    @Override
+    public Map<Long, SearchReprocessResultDto> available(Long userId) {
+        String key = getKey(userId);
+        return redisDAO.hgetAll(key).entrySet().stream()
+                .collect(Collectors.toMap(e -> Long.valueOf(e.getKey()), e -> deserialize(e.getValue())));
+    }
+
+    @Override
+    public void remove(Long userId, Set<Long> downloadedReprocessIds) {
+        String key = getKey(userId);
+        redisDAO.hdel(key, downloadedReprocessIds.stream().map(String::valueOf).collect(toSet()));
+    }
+
+    private String getKey(Long userId) {
+        return String.valueOf(userId);
+    }
+
+    private String serialize(SearchReprocessResultDto searchReprocessResult) {
+        try {
+            return objectMapper.writeValueAsString(searchReprocessResult);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private SearchReprocessResultDto deserialize(String searchReprocessResult) {
+        try {
+            return objectMapper.readValue(searchReprocessResult, SearchReprocessResultDto.class);
+        } catch (IOException e) {
+            log.error("Deserialize exception", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/songbox/house/service/MusicCollectionService.java
+++ b/src/main/java/songbox/house/service/MusicCollectionService.java
@@ -13,6 +13,8 @@ public interface MusicCollectionService {
 
     MusicCollection findById(Long collectionId);
 
+    MusicCollection findById(Long collectionId, Long ownerId);
+
     void delete(Long collectionId);
 
     void checkOwner(Long collectionId);
@@ -24,4 +26,6 @@ public interface MusicCollectionService {
     MusicCollection getOrCreate(String name);
 
     boolean checkCanGet(final Set<MusicCollection> collections);
+
+    MusicCollection getOrCreateDefault();
 }

--- a/src/main/java/songbox/house/service/TrackService.java
+++ b/src/main/java/songbox/house/service/TrackService.java
@@ -15,6 +15,8 @@ public interface TrackService {
 
     Track save(final Track track, final Set<String> genres, final Long collectionId);
 
+    Track save(final Track track, final Set<String> genres, final Long collectionId, final Long ownerId);
+
     Track findByArtistAndTitle(final String artist, final String title);
 
     Integer deleteAllTracks(final Long collectionId);

--- a/src/main/java/songbox/house/service/UserPropertyService.java
+++ b/src/main/java/songbox/house/service/UserPropertyService.java
@@ -1,10 +1,15 @@
 package songbox.house.service;
 
 import songbox.house.domain.entity.user.UserProperty;
+import songbox.house.domain.entity.user.UserPropertyMask;
+
+import java.util.Collection;
 
 public interface UserPropertyService {
     UserProperty getCurrentUserProperty();
     void saveUserProperty(UserProperty userProperty);
     boolean isUseGoogleDrive();
     long getCurrentMusicCollectionId();
+    void setMasks(UserProperty userProperty, Collection<UserPropertyMask> masks);
+    void removeMasks(UserProperty userProperty, Collection<UserPropertyMask> masks);
 }

--- a/src/main/java/songbox/house/service/UserService.java
+++ b/src/main/java/songbox/house/service/UserService.java
@@ -9,6 +9,8 @@ public interface UserService {
 
     UserInfo findByUserName(String userName);
 
+    UserInfo findById(Long id);
+
     UserInfo createAdminIfNotExists();
 
     UserInfo createUser(final UserDto userDto);

--- a/src/main/java/songbox/house/service/impl/UserPropertyServiceImpl.java
+++ b/src/main/java/songbox/house/service/impl/UserPropertyServiceImpl.java
@@ -5,14 +5,19 @@ import org.springframework.stereotype.Service;
 import songbox.house.domain.entity.MusicCollection;
 import songbox.house.domain.entity.user.UserInfo;
 import songbox.house.domain.entity.user.UserProperty;
+import songbox.house.domain.entity.user.UserPropertyMask;
 import songbox.house.repository.UserInfoRepository;
 import songbox.house.repository.UserPropertyRepository;
 import songbox.house.service.MusicCollectionService;
 import songbox.house.service.UserPropertyService;
 import songbox.house.service.UserService;
 
+import java.util.Collection;
+
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
+import static songbox.house.util.MaskUtil.removeMask;
+import static songbox.house.util.MaskUtil.setMask;
 
 @Service
 @AllArgsConstructor
@@ -27,6 +32,7 @@ public class UserPropertyServiceImpl implements UserPropertyService {
         UserInfo currentUser = userService.getCurrentUser();
         UserProperty userProperty = currentUser.getUserProperty();
 
+        //TODO remove after clearing DB
         if (currentUser.getUserProperty() == null) {
             userProperty = new UserProperty();
             currentUser.setUserProperty(userProperty);
@@ -50,6 +56,20 @@ public class UserPropertyServiceImpl implements UserPropertyService {
         return ofNullable(getCurrentUserProperty().getDefaultCollection())
                 .map(MusicCollection::getCollectionId)
                 .orElseGet(() -> musicCollectionService.getOrCreateDefault().getCollectionId());
+    }
+
+    @Override
+    public void setMasks(UserProperty userProperty, Collection<UserPropertyMask> masks) {
+        Long currentMask = userProperty.getMask();
+        masks.forEach(userPropertyMask -> setMask(currentMask, userPropertyMask));
+        saveUserProperty(userProperty);
+    }
+
+    @Override
+    public void removeMasks(UserProperty userProperty, Collection<UserPropertyMask> masks) {
+        Long currentMask = userProperty.getMask();
+        masks.forEach(userPropertyMask -> removeMask(currentMask, userPropertyMask));
+        saveUserProperty(userProperty);
     }
 
 }

--- a/src/main/java/songbox/house/service/impl/UserPropertyServiceImpl.java
+++ b/src/main/java/songbox/house/service/impl/UserPropertyServiceImpl.java
@@ -49,7 +49,7 @@ public class UserPropertyServiceImpl implements UserPropertyService {
     public long getCurrentMusicCollectionId() {
         return ofNullable(getCurrentUserProperty().getDefaultCollection())
                 .map(MusicCollection::getCollectionId)
-                .orElseGet(() -> musicCollectionService.getOrCreate("Default Collection " + userService.getCurrentUserName().hashCode()).getCollectionId());
+                .orElseGet(() -> musicCollectionService.getOrCreateDefault().getCollectionId());
     }
 
 }

--- a/src/main/java/songbox/house/service/impl/UserServiceImpl.java
+++ b/src/main/java/songbox/house/service/impl/UserServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import songbox.house.domain.dto.request.UserDto;
 import songbox.house.domain.entity.user.UserInfo;
+import songbox.house.domain.entity.user.UserProperty;
 import songbox.house.domain.entity.user.UserRole;
 import songbox.house.exception.NotExistsException;
 import songbox.house.repository.UserInfoRepository;
@@ -17,6 +18,7 @@ import songbox.house.service.UserService;
 import java.util.Optional;
 
 import static java.text.MessageFormat.format;
+import static java.util.Objects.isNull;
 import static songbox.house.domain.entity.user.UserRole.RoleName.ADMIN;
 import static songbox.house.domain.entity.user.UserRole.RoleName.USER;
 
@@ -71,13 +73,21 @@ public class UserServiceImpl implements UserService {
         userInfo.setName(userDto.getName());
         userInfo.setSurname(userDto.getSurname());
         userInfo.setRole(userRoleService.findByName(USER));
+        userInfo.setUserProperty(new UserProperty());
 
         return userInfoRepository.save(userInfo);
     }
 
     @Override
     public UserInfo getCurrentUser() {
-        return findByUserName(getCurrentUserName());
+        final UserInfo currentUser = findByUserName(getCurrentUserName());
+
+        //TODO remove after clearing DB
+        if (isNull(currentUser.getUserProperty())) {
+            currentUser.setUserProperty(new UserProperty());
+            userInfoRepository.save(currentUser);
+        }
+        return currentUser;
     }
 
     @Override
@@ -121,6 +131,10 @@ public class UserServiceImpl implements UserService {
 
         final UserRole adminRole = userRoleService.createRoleIfNotExists(ADMIN);
         admin.setRole(adminRole);
+
+        if (isNull(admin.getUserProperty())) {
+            admin.setUserProperty(new UserProperty());
+        }
     }
 
     private UserInfo createAdmin() {

--- a/src/main/java/songbox/house/service/impl/UserServiceImpl.java
+++ b/src/main/java/songbox/house/service/impl/UserServiceImpl.java
@@ -109,6 +109,12 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new NotExistsException(format("User with name {0} not exists.", userName)));
     }
 
+    @Override
+    public UserInfo findById(Long id) {
+        return userInfoRepository.findById(id)
+                .orElseThrow(() -> new NotExistsException(format("User with id {0} not exists.", id)));
+    }
+
     private void setRequiredAdminFields(final UserInfo admin) {
         admin.setActive(true);
         admin.setPassword(strongPasswordEncryptor.encryptPassword(adminPassword));

--- a/src/main/java/songbox/house/service/search/SearchReprocessService.java
+++ b/src/main/java/songbox/house/service/search/SearchReprocessService.java
@@ -1,0 +1,32 @@
+package songbox.house.service.search;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import songbox.house.domain.entity.SearchReprocess;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.runAsync;
+
+public interface SearchReprocessService {
+    SearchReprocess createIfNotExists(String searchQuery, Long collectionId, Set<String> genres, Long userId);
+
+    Page<SearchReprocess> availableForSearch(Long userId, Pageable pageable);
+
+    Page<SearchReprocess> availableForDownloading(Long userId, Pageable pageable);
+
+    Page<SearchReprocess> downloaded(Long userId, Pageable pageable);
+
+    void download(Long userId, Set<Long> searchReprocessIds);
+
+    void downloadAll(Long userId);
+
+    default CompletableFuture<Void> reprocessAllUsersAsync() {
+        return runAsync(this::reprocessAllUsers);
+    }
+
+    void reprocessAllUsers();
+
+    void reprocess(Long userId);
+}

--- a/src/main/java/songbox/house/service/search/TrackDownloadService.java
+++ b/src/main/java/songbox/house/service/search/TrackDownloadService.java
@@ -4,11 +4,25 @@ import songbox.house.domain.dto.request.SaveSongsDto;
 import songbox.house.domain.dto.request.SearchRequestDto;
 import songbox.house.domain.dto.response.SongDto;
 import songbox.house.domain.dto.response.TrackDto;
+import songbox.house.domain.dto.response.TrackMetadataDto;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 public interface TrackDownloadService {
     Optional<TrackDto> searchAndDownload(final SearchRequestDto searchRequest);
+
+    Optional<TrackDto> download(TrackMetadataDto trackMetadataDto, Long collectionId, Long ownerId,
+            Set<String> genres);
+
+    default CompletableFuture<Optional<TrackDto>> downloadAsync(TrackMetadataDto trackMetadataDto,
+            Long collectionId, Long ownerId, Set<String> genres) {
+
+        return supplyAsync(() -> download(trackMetadataDto, collectionId, ownerId, genres));
+    }
 
     void searchAndDownloadAsync(final SearchRequestDto searchRequest);
 

--- a/src/main/java/songbox/house/service/search/impl/SearchReprocessServiceImpl.java
+++ b/src/main/java/songbox/house/service/search/impl/SearchReprocessServiceImpl.java
@@ -1,0 +1,226 @@
+package songbox.house.service.search.impl;
+
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import songbox.house.domain.dto.SearchReprocessResultDto;
+import songbox.house.domain.dto.request.SearchQueryDto;
+import songbox.house.domain.dto.response.TrackMetadataDto;
+import songbox.house.domain.entity.SearchReprocess;
+import songbox.house.event.SearchReprocessFoundEvent;
+import songbox.house.repository.SearchReprocessRepository;
+import songbox.house.repository.SearchReprocessResultRepository;
+import songbox.house.service.search.SearchReprocessService;
+import songbox.house.service.search.SearchServiceFacade;
+import songbox.house.service.search.TrackDownloadService;
+import songbox.house.util.ArtistsTitle;
+import songbox.house.util.Pair;
+import songbox.house.util.compare.TrackMetadataComparator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.lang.String.join;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static lombok.AccessLevel.PRIVATE;
+import static songbox.house.domain.entity.SearchReprocessStatus.DOWNLOADED;
+import static songbox.house.domain.entity.SearchReprocessStatus.FOUND;
+import static songbox.house.domain.entity.SearchReprocessStatus.NOT_FOUND;
+
+@Service
+@Slf4j
+@FieldDefaults(makeFinal = true, level = PRIVATE)
+@AllArgsConstructor
+public class SearchReprocessServiceImpl implements SearchReprocessService {
+
+    SearchReprocessRepository repository;
+    SearchReprocessResultRepository reprocessResultRepository;
+    SearchServiceFacade searchServiceFacade;
+    TrackDownloadService downloadService;
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    @Transactional
+    public SearchReprocess createIfNotExists(String searchQuery, Long collectionId, Set<String> genres, Long userId) {
+        return repository.findByUserIdAndSearchQuery(userId, searchQuery)
+                .map(searchReprocess -> {
+                    if (DOWNLOADED == searchReprocess.getStatus()) {
+                        repository.setNotFoundById(searchReprocess.getId());
+                    }
+                    return searchReprocess;
+                })
+                .orElseGet(() -> create(searchQuery, collectionId, genres, userId));
+    }
+
+    @Override
+    public Page<SearchReprocess> availableForSearch(Long userId, Pageable pageable) {
+        return findNotFound(userId, pageable);
+    }
+
+    @Override
+    @Transactional
+    public Page<SearchReprocess> availableForDownloading(Long userId, Pageable pageable) {
+        checkConsistency(userId);
+        return repository.findByUserIdAndStatus(userId, FOUND, pageable);
+    }
+
+    @Override
+    public Page<SearchReprocess> downloaded(Long userId, Pageable pageable) {
+        return repository.findByUserIdAndStatus(userId, DOWNLOADED, pageable);
+    }
+
+    @Override
+    @Transactional
+    public void download(Long userId, Set<Long> searchReprocessIds) {
+        log.info("Starting downloading search reprocess ids {} for user {}", searchReprocessIds, userId);
+        Map<Long, SearchReprocessResultDto> readyForDownloading =
+                reprocessResultRepository.get(userId, searchReprocessIds);
+
+        int downloaded = download(userId, readyForDownloading);
+        log.info("Downloaded {} tracks for user {}", downloaded, userId);
+    }
+
+    @Override
+    @Transactional
+    public void downloadAll(Long userId) {
+        log.info("Starting downloading all search reprocess ids for user {}", userId);
+        Map<Long, SearchReprocessResultDto> readyForDownloading = reprocessResultRepository.available(userId);
+
+        int downloaded = download(userId, readyForDownloading);
+        log.info("Downloaded {} tracks for user {}", downloaded, userId);
+    }
+
+    @Override
+    @Transactional
+    @Scheduled(cron = "${songbox.house.reprocess.cron:0 0 0 * * *}")
+    public void reprocessAllUsers() {
+        log.info("Starting reprocessing search requests for all users");
+        repository.findAllUsersForReprocess(NOT_FOUND).forEach(this::reprocess);
+        log.info("Finished reprocessing search requests for all users");
+    }
+
+    @Override
+    @Transactional
+    public void reprocess(Long userId) {
+        log.info("Starting reprocessing search requests for user {}", userId);
+        checkConsistency(userId);
+
+        Map<Long, SearchReprocessResultDto> reprocessResult = new HashMap<>();
+
+        int pageNumber = 0;
+        Page<SearchReprocess> batch;
+        do {
+            //TODO config
+            Pageable pageable = PageRequest.of(pageNumber, 20);
+            batch = repository.findByUserIdAndStatus(userId, NOT_FOUND, pageable);
+            reprocessResult.putAll(reprocessBatch(batch.getContent()));
+            repository.incrementRetryCount(batch.stream().map(SearchReprocess::getId).collect(toSet()));
+            pageNumber++;
+        } while (batch.hasNext());
+
+        if (!reprocessResult.isEmpty()) {
+            reprocessResultRepository.save(userId, reprocessResult);
+            repository.setFound(new Date(), new ArrayList<>(reprocessResult.keySet()));
+            applicationEventPublisher.publishEvent(new SearchReprocessFoundEvent(this, userId, reprocessResult));
+            //TODO check user property -> if auto download after reprocessing -> downloadAll(userId)
+        }
+        log.info("Finished reprocessing search requests for user {}, found {}", userId, reprocessResult.size());
+    }
+
+    private Optional<Long> downloadOne(Long searchReprocessId, SearchReprocessResultDto resultDto) {
+        return downloadService.download(resultDto.getTrackMetadata(), resultDto.getCollectionId(),
+                resultDto.getOwnerId(), resultDto.getGenres())
+                .map(t -> searchReprocessId);
+    }
+
+    private int download(Long userId, Map<Long, SearchReprocessResultDto> readyForDownloading) {
+        final Set<Long> downloadedReprocessIds = readyForDownloading.entrySet().stream()
+                .map(entry -> downloadOne(entry.getKey(), entry.getValue()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toSet());
+
+        if (!downloadedReprocessIds.isEmpty()) {
+            repository.setDownloaded(new Date(), downloadedReprocessIds);
+            reprocessResultRepository.remove(userId, downloadedReprocessIds);
+        }
+
+        return downloadedReprocessIds.size();
+    }
+
+    private void checkConsistency(Long userId) {
+        Set<Long> availableReprocessIds = reprocessResultRepository.available(userId).keySet();
+        if (!availableReprocessIds.isEmpty()) {
+            repository.setNotFound(availableReprocessIds);
+        } else {
+            repository.setNotFound(userId);
+        }
+    }
+
+    private Map<Long, SearchReprocessResultDto> reprocessBatch(Collection<SearchReprocess> batch) {
+        //TODO parallel if need
+        return batch.stream()
+                .map(this::reprocessOneSearch)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toMap(Pair::getLeft, Pair::getRight));
+    }
+
+    private Optional<Pair<Long, SearchReprocessResultDto>> reprocessOneSearch(SearchReprocess searchReprocess) {
+        String searchQuery = searchReprocess.getSearchQuery();
+        SearchQueryDto searchQueryDto = new SearchQueryDto(searchQuery);
+        //TODO config
+        TrackMetadataComparator comparator = new TrackMetadataComparator(ArtistsTitle.parse(searchQuery), 85);
+
+        List<TrackMetadataDto> searchResult = searchServiceFacade.search(searchQueryDto).stream()
+                .sorted(comparator.reversed())
+                .collect(toList());
+
+        if (searchResult.isEmpty()) {
+            return Optional.empty();
+        } else {
+            log.debug("Reprocess search result sorted {}, saving 1st element as result", searchResult);
+            final TrackMetadataDto foundTrackMetadata = searchResult.get(0);
+            SearchReprocessResultDto resultDto = new SearchReprocessResultDto();
+            resultDto.setTrackMetadata(foundTrackMetadata);
+            resultDto.setCollectionId(searchReprocess.getCollectionId());
+            resultDto.setOwnerId(searchReprocess.getUserId());
+            final Set<String> genres = Stream.of(searchReprocess.getGenres().split(","))
+                    .filter(StringUtils::isNotBlank)
+                    .collect(toSet());
+            resultDto.setGenres(genres);
+            return Optional.of(Pair.of(searchReprocess.getId(), resultDto));
+        }
+    }
+
+    private Page<SearchReprocess> findNotFound(Long userId, Pageable pageable) {
+        return repository.findByUserIdAndStatus(userId, NOT_FOUND, pageable);
+    }
+
+    private SearchReprocess create(String searchQuery, Long collectionId, Set<String> genres, Long userId) {
+        SearchReprocess searchReprocess = new SearchReprocess();
+        searchReprocess.setSearchQuery(searchQuery);
+        searchReprocess.setCollectionId(collectionId);
+        searchReprocess.setUserId(userId);
+        searchReprocess.setGenres(join(",", genres));
+        return repository.save(searchReprocess);
+    }
+
+}


### PR DESCRIPTION
Dev: refactor MusicCollectionService - return default collection instead of throwing an exception
Dev: implement scheduled search reprocessing(SearchReprocess, SearchReprocessService)
Dev: add SearchReprocessFoundEvent(and LoggingSearchReprocessFoundEventListener to show that event works)
Dev: add in-memory implementation of storage for found track during search reprocessing(InMemorySearchReprocessResultRepository)
Dev: add UserPropertyMask with 5 flags
Dev: add dependency songbox-house-redis-dao
Dev: add redis implementation of storage for found track during search reprocessing(RedisSearchReprocessResultRepository)




**Usage:**
Invoke `SearchReprocessService#createIfNotExists` if the user wants to reprocess search query later(most useful, when a search result is empty). As a result, the search query will be stored in the SQL storage. 
`SearchReprocessService#reprocessAllUsers` is executing by schedule and performing a search by all available to reprocess search queries in the SQL storage. If something found, it will be stored into the cache, event `SearchReprocessFoundEvent` will be raised as well(especially, to notify a user about successful search reprocessing). 
After that user could select some search results, and download them, using `SearchReprocessService#download`. Also, it is a possibility to download all available search reprocessing results for user - `SearchReprocessService#downloadAll`.
Maybe will be useful to have a possibility for the user to trigger reprocessing of all requests - `SearchReprocessService#reprocess`


`SearchReprocessService#availableForSearch` returns a page of **available for search** reprocessing requests for user
`SearchReprocessService#availableForDownloading` returns a page of **found(ready to download)** by reprocessing search reprocessing requests for user
`SearchReprocessService#downloaded` returns a page of **downloaded** by reprocessing search reprocessing requests for user

